### PR TITLE
SafeHaskell support

### DIFF
--- a/Control/Monad/Loc.hs
+++ b/Control/Monad/Loc.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702)
+{-# LANGUAGE Safe #-}
+#endif
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -16,13 +19,9 @@
      { -\# OPTIONS_GHC -F -pgmF MonadLoc \#- }
 @
 
- * There is also the TH macro 'withLocTH' to manually annotate program points,
-   but you should always use the preprocessor if possible.
+ * There is also the TH macro 'withLocTH' exported by "Control.Monad.Loc.TH"
 -}
-module Control.Monad.Loc (MonadLoc(..), withLocTH) where
-import Language.Haskell.TH.Syntax (qLocation, Loc(..), Q, Exp)
-import Prelude hiding (mod)
-import Text.Printf
+module Control.Monad.Loc (MonadLoc(..)) where
 
 -- | Generating stack traces for failures
 class Monad m => MonadLoc m where
@@ -32,26 +31,3 @@ class Monad m => MonadLoc m where
   withLoc :: String -> m a -> m a
 
 instance Monad m => MonadLoc m where withLoc _ = id;
-
-
--- | 'withLocTH' is a convenient TH macro which expands to 'withLoc' @\<source location\>@
---    It should only be used when the MonadLoc preprocessor is not available.
---    Usage:
---
---    > f x = $withLocTH $ do
---    >          $withLocTH $ something
---    >          x < -$withLocTH $ something-else
---    >          ...
---
---   NOTE: unfortunately type signatures are necessary when using withLocTH
-
-withLocTH :: Q Exp
-withLocTH = do
-  loc <- qLocation
-  let loc_msg = showLoc loc
-  [| withLoc loc_msg |]
-
-showLoc :: Loc -> String
-showLoc Loc{loc_module=mod, loc_filename=filename, loc_start=start} =
-                     {- text package <> char '.' <> -}
-                     printf "%s (%s). %s" mod filename (show start)

--- a/Control/Monad/Loc/TH.hs
+++ b/Control/Monad/Loc/TH.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | The TH macro 'withLocTH' to manually annotate program points,
+--   but you should always use the preprocessor if possible.
+
+module Control.Monad.Loc.TH (withLocTH) where
+
+import Prelude hiding (mod)
+import Language.Haskell.TH.Syntax (qLocation, Loc(..), Q, Exp)
+import Text.Printf
+import Control.Monad.Loc
+
+-- | 'withLocTH' is a convenient TH macro which expands to 'withLoc' @\<source location\>@
+--    It should only be used when the MonadLoc preprocessor is not available.
+--    Usage:
+--
+--    > f x = $withLocTH $ do
+--    >          $withLocTH $ something
+--    >          x < -$withLocTH $ something-else
+--    >          ...
+--
+--   NOTE: unfortunately type signatures are necessary when using withLocTH
+
+withLocTH :: Q Exp
+withLocTH = do
+  loc <- qLocation
+  let loc_msg = showLoc loc
+  [| withLoc loc_msg |]
+
+showLoc :: Loc -> String
+showLoc Loc{loc_module=mod, loc_filename=filename, loc_start=start} =
+                     {- text package <> char '.' <> -}
+                     printf "%s (%s). %s" mod filename (show start)

--- a/monadloc.cabal
+++ b/monadloc.cabal
@@ -1,5 +1,5 @@
 name: monadloc
-version: 0.6
+version: 0.7
 Cabal-Version:  >= 1.6
 build-type: Simple
 license: PublicDomain
@@ -24,6 +24,7 @@ description:
 
   /Changes/:
   .
+      * 0.7 - Extracted Template Haskell macro to separate module to allow @Control.Monad.Loc@ to be Safe.
       * 0.6 - Extracted the preprocessor to a separate package @monadloc-pp@ to minimize the set of dependencies.
 
 Library
@@ -31,9 +32,9 @@ Library
   build-depends: base >= 4 && < 5, template-haskell, transformers
   
   ghc-options: -Wall -fno-warn-orphans
-  extensions:  FlexibleInstances, OverlappingInstances, UndecidableInstances, TemplateHaskell, PatternGuards
   exposed-modules:
      Control.Monad.Loc
+     Control.Monad.Loc.TH
      Control.Monad.Loc.Transformers
 
 source-repository head


### PR DESCRIPTION
SafeHaskell disallows TH, I moved the TH macro to a different module so that Control.Monad.Loc can be compiled with -XSafe
